### PR TITLE
🧹 remove unused type guard functions

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -127,18 +127,6 @@ export interface ServerIdentifier {
   port: number;
 }
 
-// Type guards
-export const isValidSortType = (value: string): value is SortType => {
-  return SORT_TYPES.includes(value as SortType);
-};
-
-export const isValidListType = (value: string): value is ListType => {
-  return LIST_TYPES.includes(value as ListType);
-};
-
-export const isValidSAMPVersion = (value: string): value is SAMPDLLVersions => {
-  return SAMP_DLL_VERSIONS.includes(value as SAMPDLLVersions);
-};
 
 // Helper functions for server operations
 export const getServerEndpoint = (server: ServerIdentifier): ServerEndpoint => {


### PR DESCRIPTION
🎯 **What:** Removed unused type guard functions `isValidSortType`, `isValidListType`, and `isValidSAMPVersion` from `src/utils/types.ts`.

💡 **Why:** These functions were identified as dead code and were not being used anywhere in the codebase. Removing them improves maintainability and readability.

✅ **Verification:**
- Used `grep` to confirm the functions are not referenced anywhere else in the project.
- Manually inspected related utility files to ensure no implicit usage.
- Code review confirmed the safety of the change.

✨ **Result:** A cleaner codebase with less dead code.

---
*PR created automatically by Jules for task [15633179071622025289](https://jules.google.com/task/15633179071622025289) started by @CanerKaraca23*