### PR TITLE
🔒 [security fix] Arbitrary File Read via get_checksum_of_files

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -5,7 +5,6 @@ use sevenz_rust::decompress_file;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
-use tauri::Manager;
 
 #[tauri::command]
 pub async fn inject(

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -4,6 +4,8 @@ use md5::compute;
 use sevenz_rust::decompress_file;
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
+use tauri::Manager;
 
 #[tauri::command]
 pub async fn inject(
@@ -117,12 +119,41 @@ pub fn is_process_alive(pid: u32) -> bool {
 }
 
 #[tauri::command]
-pub fn get_checksum_of_files(list: Vec<String>) -> std::result::Result<Vec<String>, String> {
+pub fn get_checksum_of_files(
+    app_handle: tauri::AppHandle,
+    list: Vec<String>,
+) -> std::result::Result<Vec<String>, String> {
     let mut result = Vec::new();
 
+    let app_local_data_dir = app_handle
+        .path_resolver()
+        .app_local_data_dir()
+        .ok_or_else(|| "Failed to get app local data directory".to_string())?;
+
+    // We canonicalize the base directory to handle symlinks and different path formats (e.g. UNC paths on Windows)
+    // If it doesn't exist, we can't really validate against it.
+    let canonical_app_local_data_dir = app_local_data_dir.canonicalize().map_err(|e| {
+        format!(
+            "Failed to canonicalize app local data directory '{}': {}",
+            app_local_data_dir.display(),
+            e
+        )
+    })?;
+
     for file in list {
-        let mut f =
-            File::open(&file).map_err(|e| format!("Failed to open file '{}': {}", file, e))?;
+        let path = Path::new(&file);
+
+        // Canonicalize the input path to resolve any .. or symlinks
+        let canonical_path = path
+            .canonicalize()
+            .map_err(|e| format!("Failed to open file '{}': {}", file, e))?;
+
+        if !canonical_path.starts_with(&canonical_app_local_data_dir) {
+            return Err(format!("Access to file '{}' is not allowed", file));
+        }
+
+        let mut f = File::open(&canonical_path)
+            .map_err(|e| format!("Failed to open file '{}': {}", file, e))?;
 
         let mut contents = Vec::new();
         f.read_to_end(&mut contents)


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Fixed an arbitrary file read vulnerability in the `get_checksum_of_files` Tauri command.

### ⚠️ Risk: The potential impact if left unfixed
An attacker capable of executing JavaScript in the frontend could use this command to check the existence and MD5 hash of any file on the user's system that the application has permissions to read. This could lead to information disclosure.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix restricts the `get_checksum_of_files` command to only operate on files within the application's local data directory. It uses Rust's `std::path::Path::canonicalize()` to resolve any path traversal components (like `..`) and symbolic links before verifying that the resulting path starts with the allowed base directory. This ensures that even if an attacker provides a manipulated path, they cannot escape the intended directory.

---
*PR created automatically by Jules for task [6420984139612374959](https://jules.google.com/task/6420984139612374959) started by @CanerKaraca23*